### PR TITLE
Automatically set the GVSP Packet size.

### DIFF
--- a/include/avt_vimba_camera/vimba_ros.h
+++ b/include/avt_vimba_camera/vimba_ros.h
@@ -159,6 +159,7 @@ class VimbaROS {
     bool getFeatureValue(const std::string& feature_str, std::string& val);
     template<typename T> bool setFeatureValue(const std::string& feature_str, const T& val);
     bool runCommand(const std::string& command_str);
+    bool runCommand(const std::string& command_str, CameraPtr camera);
 
     void updateAcquisitionConfig(const Config& config, FeaturePtrVector feature_ptr_vec);
     void updateExposureConfig(const Config& config, FeaturePtrVector feature_ptr_vec);

--- a/src/vimba_ros.cpp
+++ b/src/vimba_ros.cpp
@@ -1146,20 +1146,7 @@ CameraPtr VimbaROS::openCamera(std::string id_str) {
       // From the SynchronousGrab API example:
       // Set the GeV packet size to the highest possible value
       if ( cam_int_type == VmbInterfaceEthernet ){
-        FeaturePtr pCommandFeature;
-        if ( VmbErrorSuccess == camera->GetFeatureByName("GVSPAdjustPacketSize", pCommandFeature)){
-          if ( VmbErrorSuccess == pCommandFeature->RunCommand() ){
-            bool bIsCommandDone = false;
-            do {
-              err = pCommandFeature->IsCommandDone(bIsCommandDone);
-              if ( VmbErrorSuccess != err ){
-                ROS_ERROR_STREAM("[" << ros::this_node::getName() << "]: Could not set GVSP Packet Size on camera " << id_str
-                  << "\n Error: " << errorCodeToMessage(err));
-                break;
-              }
-            } while ( false == bIsCommandDone );
-          }
-        }
+        runCommand("GVSPAdjustPacketSize");
       }
       //printAllCameraFeatures(camera);
     } else {

--- a/src/vimba_ros.cpp
+++ b/src/vimba_ros.cpp
@@ -1104,6 +1104,24 @@ CameraPtr VimbaROS::openCamera(std::string id_str) {
 
     err = camera->Open(VmbAccessModeFull);
     if (VmbErrorSuccess == err){
+      // From the SynchronousGrab API example:
+      // Set the GeV packet size to the highest possible value
+      if ( cam_int_type == VmbInterfaceEthernet ){
+        FeaturePtr pCommandFeature;
+        if ( VmbErrorSuccess == camera->GetFeatureByName("GVSPAdjustPacketSize", pCommandFeature)){
+          if ( VmbErrorSuccess == pCommandFeature->RunCommand() ){
+            bool bIsCommandDone = false;
+            do {
+              err = pCommandFeature->IsCommandDone(bIsCommandDone);
+              if ( VmbErrorSuccess != err ){
+                ROS_ERROR_STREAM("[AVT_Vimba_ROS]: Could not set GVSP Packet Size on camera " << id_str
+                  << "\n Error: " << errorCodeToMessage(err));
+                break;
+              }
+            } while ( false == bIsCommandDone );
+          }
+        }
+      }
       printAllCameraFeatures(camera);
     } else {
       ROS_ERROR_STREAM("[AVT_Vimba_ROS]: Could not get camera " << id_str

--- a/src/vimba_ros.cpp
+++ b/src/vimba_ros.cpp
@@ -979,8 +979,12 @@ bool VimbaROS::setFeatureValue(const std::string& feature_str, const T& val) {
 
 // Template function to RUN a command
 bool VimbaROS::runCommand(const std::string& command_str) {
+  return runCommand(command_str, vimba_camera_ptr_);
+}
+
+bool VimbaROS::runCommand(const std::string& command_str, CameraPtr camera) {
   FeaturePtr feature_ptr;
-  if ( VmbErrorSuccess == vimba_camera_ptr_->GetFeatureByName( command_str.c_str(), feature_ptr ))
+  if ( VmbErrorSuccess == camera->GetFeatureByName( command_str.c_str(), feature_ptr ))
   {
     if ( VmbErrorSuccess == feature_ptr->RunCommand() )
     {
@@ -1146,7 +1150,7 @@ CameraPtr VimbaROS::openCamera(std::string id_str) {
       // From the SynchronousGrab API example:
       // Set the GeV packet size to the highest possible value
       if ( cam_int_type == VmbInterfaceEthernet ){
-        runCommand("GVSPAdjustPacketSize");
+        runCommand("GVSPAdjustPacketSize", camera);
       }
       //printAllCameraFeatures(camera);
     } else {


### PR DESCRIPTION
This is necessary at least for the G-046C, and it's being done by the
API examples, too. Without it, the node receives frames which don't fail but have 0 data size.
