### PR TITLE
Allow user to connect by specifying either GUID or IP address.

### DIFF
--- a/cfg/AvtVimbaCamera.cfg
+++ b/cfg/AvtVimbaCamera.cfg
@@ -71,8 +71,8 @@ sync_source_enum = gen.enum([ gen.const("GPO", str_t, "GPO", ""),
 							  gen.const("LineIn2",                 str_t, "LineIn2", "")],"Sync-out signal")
 
 #       Name                    Type      Reconfiguration level             Description         Default   Min   Max
-gen.add("guid",					str_t,    SensorLevels.RECONFIGURE_CLOSE,   "Global Unique ID of camera, XX-XXXXXXXXXX digits","50-0503328910")
-gen.add("ip_address",			str_t,    SensorLevels.RECONFIGURE_CLOSE,   "IP of camera, four pairs of two digits separated by points: 192.168.1.3","192.168.3.103")
+gen.add("guid",					str_t,    SensorLevels.RECONFIGURE_CLOSE,   "Global Unique ID of camera, XX-XXXXXXXXXX digits","")
+gen.add("ip_address",			str_t,    SensorLevels.RECONFIGURE_CLOSE,   "IP of camera, four pairs of two digits separated by points: 192.168.1.3","")
 # ROS
 gen.add("camera_info_url", 		str_t,    SensorLevels.RECONFIGURE_RUNNING, "Camera calibration URL for this video_mode (uncalibrated if null).","camera_info.yaml")
 gen.add("frame_id",             str_t,    SensorLevels.RECONFIGURE_RUNNING, "The optical camera TF frame set in message headers.", "camera")

--- a/src/vimba_ros.cpp
+++ b/src/vimba_ros.cpp
@@ -115,6 +115,9 @@ void VimbaROS::start(Config& config) {
     // Only guid available
     ROS_INFO_STREAM("Trying to open camera by ID: " << guid_str);
     vimba_camera_ptr_ = openCamera(guid_str);
+  } else {
+    // No identifying info (GUID and IP) are available
+    ROS_ERROR("Can't connect to the camera: at least GUID or IP need to be set.");
   }
 
   // Get all cam properties we need for initialization


### PR DESCRIPTION
The code allows for using either a GUID or IP address to connect to a camera (lines 103 -- 118 of `src/vimba_ros.cpp`). However, because of the defaults given by the configuration file, IP address always has to be set after which the GUID if supplied (which is done by the configuration file) will be checked. These configuration variables do not really allow for sensible default values.

This pull request sets the default values for `guid` and `ip_address` to the empty string. By doing so, the software will look for user-specified values for these two values, and allows it when only one of the two are set. If both are set, both still have to be correct.
