### PR TITLE
Automatically set the GVSP Packet size.

### DIFF
--- a/src/vimba_ros.cpp
+++ b/src/vimba_ros.cpp
@@ -1104,6 +1104,24 @@ CameraPtr VimbaROS::openCamera(std::string id_str) {
 
     err = camera->Open(VmbAccessModeFull);
     if (VmbErrorSuccess == err){
+      // From the SynchronousGrab API example:
+      // Set the GeV packet size to the highest possible value
+      if ( cam_int_type == VmbInterfaceEthernet ){
+        FeaturePtr pCommandFeature;
+        if ( VmbErrorSuccess == camera->GetFeatureByName("GVSPAdjustPacketSize", pCommandFeature)){
+          if ( VmbErrorSuccess == pCommandFeature->RunCommand() ){
+            bool bIsCommandDone = false;
+            do {
+              err = pCommandFeature->IsCommandDone(bIsCommandDone);
+              if ( VmbErrorSuccess != err ){
+                ROS_ERROR_STREAM("[AVT_Vimba_ROS]: Could not set GVSP Packet Size on camera " << id_str
+                  << "\n Error: " << errorCodeToMessage(err));
+                break;
+              }
+            } while ( false == bIsCommandDone );
+          }
+        }
+      }
       printAllCameraFeatures(camera);
     } else {
       ROS_ERROR_STREAM("[AVT_Vimba_ROS]: Could not get camera " << id_str


### PR DESCRIPTION
This is necessary at least for the G-046C, and it's being done by the
API examples, too. Without it, the node receives frames which don't fail but have 0 data size.
