### PR TITLE
Constructor delegation is not allowed prior to C++11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
   polled_camera
 )
 
+add_definitions(--std=c++11)
+
 #Get architecture
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(TargetArchitecture)

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -84,8 +84,7 @@ static const char* State[] = {
   "Ok"};
 
 
-AvtVimbaCamera::AvtVimbaCamera() {
-  AvtVimbaCamera(ros::this_node::getName().c_str());
+AvtVimbaCamera::AvtVimbaCamera() : AvtVimbaCamera(ros::this_node::getName()){
 }
 
 AvtVimbaCamera::AvtVimbaCamera(std::string name) {
@@ -473,7 +472,7 @@ bool AvtVimbaCamera::setFeatureValue(const std::string& feature_str,
       if (writable) {
         ROS_DEBUG_STREAM("Setting feature " << feature_str << " value " << val);
         VmbFeatureDataType data_type;
-        err == vimba_feature_ptr->GetDataType(data_type);
+        err = vimba_feature_ptr->GetDataType(data_type);
         if (VmbErrorSuccess == err) {
           if (data_type == VmbFeatureDataEnum) {
             bool available;


### PR DESCRIPTION
Instead of raising errors, G++ silently allows this on my system. Bugs that are introduced:
- vimba_camera_ptr_ always equals NULL
- When printed, opened_ values from {0, 2, 106}
