### PR TITLE
Added feature for loading and saving camera_info from/to camera flash memory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   std_msgs
   polled_camera
+  camera_calibration_parsers
 )
 
 #Get architecture

--- a/include/avt_vimba_camera/avt_vimba_camera.h
+++ b/include/avt_vimba_camera/avt_vimba_camera.h
@@ -91,6 +91,10 @@ class AvtVimbaCamera {
   int getMaxWidth();
   int getMaxHeight();
 
+  std::string getCameraName();
+
+  VmbInt64_t getLutMemorySize();
+
   // Pass callback function pointer
   typedef boost::function<void (const FramePtr)> frameCallbackFunc;
   void setCallback(frameCallbackFunc callback = &avt_vimba_camera::AvtVimbaCamera::defaultFrameCallback) {
@@ -102,6 +106,13 @@ class AvtVimbaCamera {
   void startImaging(void);
   void stopImaging(void);
   bool isOpened(void) { return opened_; }
+
+  // Save camera_info to camera memory
+  VmbErrorType saveCameraMemory(UcharVector data);
+  // Load camera_info from camera_memory
+  VmbErrorType loadCameraMemory(UcharVector& data);
+  // Convert between Big Endian and Little Endian
+  UcharVector convertBigEndian(const UcharVector& data);
 
  private:
   Config config_;
@@ -126,6 +137,8 @@ class AvtVimbaCamera {
   bool on_init_;
   bool show_debug_prints_;
   std::string name_;
+
+  std::string camera_name_;
 
   diagnostic_updater::Updater updater_;
   CameraState camera_state_;

--- a/include/avt_vimba_camera/mono_camera.h
+++ b/include/avt_vimba_camera/mono_camera.h
@@ -37,7 +37,7 @@
 #include <avt_vimba_camera/AvtVimbaCameraConfig.h>
 #include <avt_vimba_camera/avt_vimba_api.h>
 
-#include <camera_calibration_parsers/parse_ini.h>
+#include <camera_calibration_parsers/parse_yml.h>
 
 #include <ros/ros.h>
 #include <sensor_msgs/Image.h>

--- a/include/avt_vimba_camera/mono_camera.h
+++ b/include/avt_vimba_camera/mono_camera.h
@@ -37,6 +37,8 @@
 #include <avt_vimba_camera/AvtVimbaCameraConfig.h>
 #include <avt_vimba_camera/avt_vimba_api.h>
 
+#include <camera_calibration_parsers/parse_ini.h>
+
 #include <ros/ros.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
@@ -62,6 +64,8 @@ class MonoCamera {
   ros::NodeHandle nh_;
   ros::NodeHandle nhp_;
 
+  bool memory_loaded_;
+
   std::string ip_;
   std::string guid_;
   std::string camera_info_url_;
@@ -70,6 +74,8 @@ class MonoCamera {
   image_transport::ImageTransport it_;
   // ROS Camera publisher
   image_transport::CameraPublisher pub_;
+  // Set camera_info service server
+  ros::ServiceServer set_camera_info_srv_;
 
 
 
@@ -80,6 +86,8 @@ class MonoCamera {
   typedef avt_vimba_camera::AvtVimbaCameraConfig Config;
   typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
   ReconfigureServer reconfigure_server_;
+
+  bool setCameraInfo(sensor_msgs::SetCameraInfo::Request& req, sensor_msgs::SetCameraInfo::Response& rsp);
 
   // Camera configuration
   Config camera_config_;

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>polled_camera</build_depend>
+  <build_depend>camera_calibration_parsers</build_depend>
   <!--build_depend>libvimba</build_depend-->
   <run_depend>camera_info_manager</run_depend>
   <run_depend>diagnostic_updater</run_depend>
@@ -35,6 +36,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>polled_camera</run_depend>
+  <run_depend>camera_calibration_parsers</run_depend>
   <!--run_depend>libvimba</run_depend-->
 
 </package>

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -1137,7 +1137,7 @@ VmbErrorType AvtVimbaCamera::saveCameraMemory(UcharVector data) {
   UcharVector data_to_write;
   for(UcharVector::iterator it = data.begin() ; it != data.end() ; it++) {
     data_to_write.push_back(*it);
-    data_to_write.push_back('\0');
+    data_to_write.push_back(' ');
   }
 
   VmbUint32_t completed_writes = 0;


### PR DESCRIPTION
I often change my camera's lens, so there is a need to calibrate camera frequently. 
For camera calibration I use camera_calibration ROS package, but it is not handy to create ini or yml calibration file and then load them.
I added feature for saving camera_info data in camera non-volatile memory. With this feature I run only camera_calibration package and it stores camera_info in camera memory.
