### PR TITLE
Set the frame_id of the image header, too.

### DIFF
--- a/src/mono_camera.cpp
+++ b/src/mono_camera.cpp
@@ -77,6 +77,7 @@ void MonoCamera::frameCallback(const FramePtr& vimba_frame_ptr) {
     if (api_.frameToImage(vimba_frame_ptr, img)) {
       sensor_msgs::CameraInfo ci = info_man_->getCameraInfo();
       ci.header.stamp = img.header.stamp = ros_time;
+      img.header.frame_id = ci.header.frame_id;
       pub_.publish(img, ci);
     } else {
       ROS_WARN_STREAM("Function frameToImage returned 0. No image published.");

--- a/src/stereo_camera.cpp
+++ b/src/stereo_camera.cpp
@@ -149,8 +149,10 @@ void StereoCamera::sync(void) {
 
       lci.header.stamp = ros_time;
       left_img_.header.stamp = ros_time;
+      left_img_.header.frame_id = lci.header.frame_id;
       rci.header.stamp = ros_time;
       right_img_.header.stamp = ros_time;
+      right_img_.header.frame_id = rci.header.frame_id;
       left_pub_.publish(left_img_, lci);
       right_pub_.publish(right_img_, rci);
       // pub_freq_->tick(ros_time);


### PR DESCRIPTION
Currently, the image's `frame_id` is empty, which it shouldn't.

This change makes things like RViz' "Camera" (not "Image") display work.
