### PR TITLE
Fix opening the camera

### DIFF
--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -298,6 +298,7 @@ CameraPtr AvtVimbaCamera::openCamera(std::string id_str) {
   }
 
   if (VmbErrorSuccess == err) {
+    err = camera->Open(VmbAccessModeFull);
     while (err != VmbErrorSuccess && keepRunning) {
       ROS_WARN_STREAM("Could not open camera. Retrying every second...");
       err = camera->Open(VmbAccessModeFull);


### PR DESCRIPTION
At the moment, the camera is never opened, so the driver always shuts down on init. The commit 457182f fixes that. The other commit (3a60691) is just a refactoring of the `openCamera()` logic, it doesn't change the behavior. In my opinion, it makes the logic easier to follow. If you don't like the second commit, only merge the first. :)