### PR TITLE
[CI] Add config for ROS Kinetic (and Lunar as an option).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# Generic UWSim Travis Continuous Integration Configuration File
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    recipients:
+      - gm130s@gmail.com
+env:
+  matrix:
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="kinetic"  PRERELEASE=true
+    - ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="lunar"  PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="kinetic"  PRERELEASE=true
+    - env: ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: ROS_DISTRO="lunar"  PRERELEASE=true
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - .ci_config/travis.sh


### PR DESCRIPTION
Adding a config for Travis CI (Continuous Integration). If this LGTY, could any admins please enable Travis (at something like https://travis-ci.org/profile/srv)? It only takes a single click to do so.

- An advantage of this CI config is, among other things, it runs [ROS prerelease tests](http://wiki.ros.org/bloom/Tutorials/PrereleaseTest) using the same setup that `ROS buildfarm (build.ros.org)` uses so that you can find early the possible build issues that could happen on the buildfarm after you make a release request (which you do on [rosdistro](https://github.com/ros/rosdistro)).
  - In fact I already ran CI [in my fork](https://travis-ci.org/130s/avt_vimba_camera/builds/260326037?utm_source=github_status&utm_medium=notification) and prerelease test passed for ROS Kinetic and Lunar, which is a good sign that we might be able to make releases into both distros without issues :)