### PR TITLE
Icicles payload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_dependencies_and_linkings(sync_node)
 add_library(avt_camera_nodelets
   src/nodes/mono_camera_nodelet.cpp
   src/nodes/stereo_camera_nodelet.cpp
+  src/mono_camera.cpp
   src/stereo_camera.cpp
   src/avt_vimba_camera.cpp
   src/frame_observer.cpp)

--- a/include/avt_vimba_camera/avt_vimba_camera.h
+++ b/include/avt_vimba_camera/avt_vimba_camera.h
@@ -112,8 +112,6 @@ class AvtVimbaCamera {
   SP_DECL(FrameObserver) frame_obs_ptr_;
   // The currently streaming camera
   CameraPtr vimba_camera_ptr_;
-  // Current frame
-  FramePtr vimba_frame_ptr_;
   // The max width
   VmbInt64_t vimba_camera_max_width_;
   // The max height

--- a/include/avt_vimba_camera/avt_vimba_camera.h
+++ b/include/avt_vimba_camera/avt_vimba_camera.h
@@ -77,7 +77,7 @@ class AvtVimbaCamera {
  public:
   AvtVimbaCamera();
   AvtVimbaCamera(std::string name);
-  void start(std::string ip_str, std::string guid_str, bool debug_prints = true);
+  void start(std::string ip_str, std::string guid_str, bool debug_prints = true, int num_frames = 3);
   void stop();
   double getTimestamp(void);
   bool resetTimestamp(void);

--- a/include/avt_vimba_camera/mono_camera.h
+++ b/include/avt_vimba_camera/mono_camera.h
@@ -68,6 +68,9 @@ class MonoCamera {
   bool show_debug_prints_;
   int num_frames_;
 
+  sensor_msgs::CameraInfo::Ptr ci_;
+  sensor_msgs::Image::Ptr img_;
+
   image_transport::ImageTransport it_;
   // ROS Camera publisher
   image_transport::CameraPublisher pub_;

--- a/include/avt_vimba_camera/mono_camera.h
+++ b/include/avt_vimba_camera/mono_camera.h
@@ -66,6 +66,7 @@ class MonoCamera {
   std::string guid_;
   std::string camera_info_url_;
   bool show_debug_prints_;
+  int num_frames_;
 
   image_transport::ImageTransport it_;
   // ROS Camera publisher

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -89,8 +89,8 @@ static const char* State[] = {
 static volatile int keepRunning = 1;
 
 void intHandler(int dummy) {
-  std::cerr << "signal received, shutting down" << std::endl;
   keepRunning = 0;
+  ros::shutdown();
 }
 
 AvtVimbaCamera::AvtVimbaCamera() : AvtVimbaCamera(ros::this_node::getName().c_str()) {
@@ -365,10 +365,7 @@ void AvtVimbaCamera::frameCallback(const FramePtr vimba_frame_ptr) {
   diagnostic_msg_ = "Camera operating normally";
 
   // Call the callback implemented by other classes
-//   boost::thread thread_callback = boost::thread(userFrameCallback, vimba_frame_ptr);
-//   thread_callback.join();
-
-  userFrameCallback(vimba_frame_ptr_);
+  userFrameCallback(vimba_frame_ptr);
 
   updater_.update();
 }

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -89,14 +89,17 @@ static const char* State[] = {
 static volatile int keepRunning = 1;
 
 void intHandler(int dummy) {
-    keepRunning = 0;
+  std::cerr << "signal received, shutting down" << std::endl;
+  keepRunning = 0;
 }
 
 AvtVimbaCamera::AvtVimbaCamera() : AvtVimbaCamera(ros::this_node::getName().c_str()) {
 
 }
 
-AvtVimbaCamera::AvtVimbaCamera(std::string name) {
+AvtVimbaCamera::AvtVimbaCamera(std::string name) :
+  num_frames_(3)
+{
   // Init global variables
   opened_ = false;   // camera connected to the api
   streaming_ = false;  // capturing frames
@@ -113,10 +116,11 @@ AvtVimbaCamera::AvtVimbaCamera(std::string name) {
   updater_.update();
 }
 
-void AvtVimbaCamera::start(std::string ip_str, std::string guid_str, bool debug_prints) {
+void AvtVimbaCamera::start(std::string ip_str, std::string guid_str, bool debug_prints, int num_frames) {
   if (opened_) return;
 
   show_debug_prints_ = debug_prints;
+  num_frames_ = num_frames;
   updater_.broadcast(0, "Starting device with IP:" + ip_str + " or GUID:" + guid_str);
 
   // Determine which camera to use. Try IP first
@@ -169,7 +173,10 @@ void AvtVimbaCamera::start(std::string ip_str, std::string guid_str, bool debug_
 
   std::string trigger_source;
   getFeatureValue("TriggerSource", trigger_source);
-  int trigger_source_int = getTriggerModeInt(trigger_source);
+  int trigger_source_int = FixedRate;
+  if (!trigger_source.empty()) {
+    getTriggerModeInt(trigger_source);
+  }
 
   if (trigger_source_int == Freerun   ||
       trigger_source_int == FixedRate ||
@@ -194,7 +201,7 @@ void AvtVimbaCamera::startImaging(void) {
   if (!streaming_) {
     // Start streaming
     VmbErrorType err =
-      vimba_camera_ptr_->StartContinuousImageAcquisition(1,  // num_frames_,
+      vimba_camera_ptr_->StartContinuousImageAcquisition(num_frames_,
       IFrameObserverPtr(frame_obs_ptr_));
     if (VmbErrorSuccess == err) {
       diagnostic_msg_ = "Starting continuous image acquisition";
@@ -395,6 +402,7 @@ bool AvtVimbaCamera::getFeatureValue(const std::string& feature_str, T& val) {
   VmbFeatureDataType data_type;
   err = vimba_camera_ptr_->GetFeatureByName(feature_str.c_str(),
                                             vimba_feature_ptr);
+
   if (VmbErrorSuccess == err) {
     bool readable;
     vimba_feature_ptr->IsReadable(readable);
@@ -432,6 +440,12 @@ bool AvtVimbaCamera::getFeatureValue(const std::string& feature_str, T& val) {
           ROS_WARN_STREAM("Could not get feature value. Error code: "
                     << api_.errorCodeToMessage(err));
         }
+        else if (show_debug_prints_) {
+          ROS_INFO_STREAM("Asking for feature "
+            << feature_str << " with datatype "
+            << FeatureDataType[data_type]
+            << " and value " << val);
+        }
       }
     } else {
       ROS_WARN_STREAM("[" << name_ << "]: Feature "
@@ -442,11 +456,7 @@ bool AvtVimbaCamera::getFeatureValue(const std::string& feature_str, T& val) {
     ROS_WARN_STREAM("[" << name_
       << "]: Could not get feature " << feature_str);
   }
-  if (show_debug_prints_)
-    ROS_INFO_STREAM("Asking for feature "
-      << feature_str << " with datatype "
-      << FeatureDataType[data_type]
-      << " and value " << val);
+
   return (VmbErrorSuccess == err);
 }
 
@@ -486,6 +496,11 @@ bool AvtVimbaCamera::getFeatureValue(const std::string& feature_str,
           ROS_WARN_STREAM("Could not get feature value. Error code: "
                     << api_.errorCodeToMessage(err));
         }
+        else if(show_debug_prints_) {
+          ROS_INFO_STREAM("Asking for feature " << feature_str
+            << " with datatype " << FeatureDataType[data_type]
+            << " and value " << val);
+        }
       }
     } else {
       ROS_WARN_STREAM("[" << name_ << "]: Feature "
@@ -495,11 +510,6 @@ bool AvtVimbaCamera::getFeatureValue(const std::string& feature_str,
   } else {
     ROS_WARN_STREAM("[" << name_
       << "]: Could not get feature " << feature_str);
-  }
-  if(show_debug_prints_) {
-    ROS_INFO_STREAM("Asking for feature " << feature_str
-      << " with datatype " << FeatureDataType[data_type]
-      << " and value " << val);
   }
   return (VmbErrorSuccess == err);
 }
@@ -791,7 +801,7 @@ void AvtVimbaCamera::updateAcquisitionConfig(Config& config) {
   }
   if (config.acquisition_rate != config_.acquisition_rate || on_init_) {
     changed = true;
-    double acquisition_frame_rate_limit;
+    double acquisition_frame_rate_limit = 120;
     getFeatureValue("AcquisitionFrameRateLimit", acquisition_frame_rate_limit);
     if (acquisition_frame_rate_limit < config.acquisition_rate) {
       double rate = (double)floor(acquisition_frame_rate_limit);

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -358,8 +358,10 @@ void AvtVimbaCamera::frameCallback(const FramePtr vimba_frame_ptr) {
   diagnostic_msg_ = "Camera operating normally";
 
   // Call the callback implemented by other classes
-  boost::thread thread_callback = boost::thread(userFrameCallback, vimba_frame_ptr);
-  thread_callback.join();
+//   boost::thread thread_callback = boost::thread(userFrameCallback, vimba_frame_ptr);
+//   thread_callback.join();
+
+  userFrameCallback(vimba_frame_ptr_);
 
   updater_.update();
 }

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -753,6 +753,21 @@ void AvtVimbaCamera::printAllCameraFeatures(const CameraPtr& camera) {
           if (VmbErrorSuccess == err) {
             std::cout << strValue << " str Enum" << std::endl;
           }
+          {
+            EnumEntryVector entries;
+            (*iter)->GetEntries(entries);
+            std::cout << "/// Entries: ";
+            for (size_t i = 0; i < entries.size(); ++i) {
+              if (i != 0) {
+                std::cout << ", ";
+              }
+              std::string name;
+              entries[i].GetName(name);
+              std::cout << "[" << name << "]";
+            }
+            std::cout << std::endl;
+          }
+
           break;
           case VmbFeatureDataFloat:
           double fValue;

--- a/src/frame_observer.cpp
+++ b/src/frame_observer.cpp
@@ -74,6 +74,9 @@ void FrameObserver::FrameReceived( const FramePtr vimba_frame_ptr )
       }
     }
   }
+  else {
+    std::cerr << "ERR: No Success receiving status" << err << std::endl;
+  }
 
-  cam_ptr_->QueueFrame( vimba_frame_ptr );
+  VmbErrorType rc = cam_ptr_->QueueFrame( vimba_frame_ptr );
 }

--- a/src/frame_observer.cpp
+++ b/src/frame_observer.cpp
@@ -53,7 +53,7 @@ FrameObserver::FrameObserver(CameraPtr cam_ptr, Callback callback) : IFrameObser
 
 void FrameObserver::FrameReceived( const FramePtr vimba_frame_ptr )
 {
-  VmbFrameStatusType eReceiveStatus;
+  VmbFrameStatusType eReceiveStatus = VmbFrameStatusComplete;
   VmbErrorType err = vimba_frame_ptr->GetReceiveStatus(eReceiveStatus);
 
   if (err == VmbErrorSuccess && eReceiveStatus == VmbFrameStatusComplete) {

--- a/src/frame_observer.cpp
+++ b/src/frame_observer.cpp
@@ -31,6 +31,7 @@
 /// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <avt_vimba_camera/frame_observer.h>
+#include <avt_vimba_camera/avt_vimba_api.h>
 
 #include <ros/console.h>
 
@@ -60,11 +61,12 @@ void FrameObserver::FrameReceived( const FramePtr vimba_frame_ptr )
   }
   else {
     char const * errorName = frameStatusNames[std::min(abs(eReceiveStatus), 3)];
-    ROS_ERROR_STREAM("FrameObserver callback error: " << err);
-  }
-  else {
-    std::cerr << "ERR: No Success receiving status" << err << std::endl;
+    ROS_ERROR_STREAM("FrameObserver callback error GetReceiveStatus() : " << errorName);
   }
 
   VmbErrorType rc = cam_ptr_->QueueFrame( vimba_frame_ptr );
+  if (rc != VmbErrorSuccess) {
+    avt_vimba_camera::AvtVimbaApi api;
+    ROS_ERROR_STREAM("FrameObserver callback error QueueFrame(): " << api.errorCodeToMessage(rc));
+  }
 }

--- a/src/mono_camera.cpp
+++ b/src/mono_camera.cpp
@@ -42,7 +42,8 @@ MonoCamera::MonoCamera(ros::NodeHandle& nh, ros::NodeHandle& nhp) :
   it_(nhp),
   cam_(ros::this_node::getName()),
   ci_(new sensor_msgs::CameraInfo()),
-  img_(new sensor_msgs::Image())
+  img_(new sensor_msgs::Image()),
+  reconfigure_server_(nhp)
 {
   // Prepare node handle for the camera
   // TODO use nodelets with getMTNodeHandle()

--- a/src/mono_camera.cpp
+++ b/src/mono_camera.cpp
@@ -55,7 +55,8 @@ MonoCamera::MonoCamera(ros::NodeHandle& nh, ros::NodeHandle& nhp) : nh_(nh), nhp
   nhp_.param("camera_info_url", camera_info_url_, std::string(""));
   std::string frame_id;
   nhp_.param("frame_id", frame_id, std::string(""));
-  nhp_.param("show_debug_prints", show_debug_prints_, false);
+  nhp_.param("show_debug_prints", show_debug_prints_, show_debug_prints_);
+  nhp_.param("num_frames", num_frames_, 3);
 
   // Set camera info manager
   info_man_  = boost::shared_ptr<camera_info_manager::CameraInfoManager>(new camera_info_manager::CameraInfoManager(nhp_, frame_id, camera_info_url_));
@@ -103,7 +104,7 @@ void MonoCamera::configure(Config& newconfig, uint32_t level) {
     // The camera already stops & starts acquisition
     // so there's no problem on changing any feature.
     if (!cam_.isOpened()) {
-      cam_.start(ip_, guid_, show_debug_prints_);
+      cam_.start(ip_, guid_, show_debug_prints_, num_frames_);
     }
 
     Config config = newconfig;

--- a/src/nodes/mono_camera_node.cpp
+++ b/src/nodes/mono_camera_node.cpp
@@ -11,5 +11,6 @@ int main(int argc, char** argv)
   avt_vimba_camera::MonoCamera mc(nh,nhp);
 
   ros::spin();
+  std::cerr << "cam node shutting down" << std::endl;
   return 0;
 }

--- a/src/nodes/mono_camera_nodelet.cpp
+++ b/src/nodes/mono_camera_nodelet.cpp
@@ -6,7 +6,7 @@ namespace avt_vimba_camera
     void MonoCameraNodelet::onInit()
     {
         NODELET_DEBUG("Initializing nodelet...");
-				camera_ = new MonoCamera(getMTNodeHandle(), getMTPrivateNodeHandle());
+				camera_ = new MonoCamera(getNodeHandle(), getPrivateNodeHandle());
     }
 
     MonoCameraNodelet::~MonoCameraNodelet()


### PR DESCRIPTION
These are a couple of fixes and improvements I applied to the sources to make them work with an Odroid ARM platform we use for rapid-prototyping for the NASA Icicles project.
 * Make frame-buffer size a parameter, as a size of 1 caused driver lock-up problems in our setup.
 * Fix parameter error processing to avoid problems with unsupported camera features
   (This allowed us to connect to a FLIR infrared camera using this AVT driver)
 * Improve rosparam namespace handling in nodelet configuration

